### PR TITLE
Use HTTPS instead of HTTP to resolve dependencies

### DIFF
--- a/eclipse-plugin/pom.xml
+++ b/eclipse-plugin/pom.xml
@@ -44,7 +44,7 @@
         <repository>
             <id>juno</id>
             <layout>p2</layout>
-            <url>http://mirrors.ustc.edu.cn/eclipse/releases/juno/</url>
+            <url>https://mirrors.ustc.edu.cn/eclipse/releases/juno/</url>
         </repository>
         <repository>
             <id>sonatype-nexus-snapshots</id>
@@ -187,7 +187,7 @@
                         <baselineReplace>none</baselineReplace>
                         <baselineRepositories>
                             <repository>
-                                <url>http://download.eclipse.org/eclipse/updates/4.4</url>
+                                <url>https://download.eclipse.org/eclipse/updates/4.4</url>
                             </repository>
                         </baselineRepositories>
                     </configuration>


### PR DESCRIPTION
This fixes a security vulnerability in this project where the `pom.xml`
files were configuring Maven to resolve dependencies over HTTP instead of
HTTPS.

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>